### PR TITLE
fix typos in READ.ME

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ writestream.end();
  *    @see moment().format(): http://momentjs.com/docs/#/displaying/format/
  *    Also support '{pid}' for process pid.
  *  - {String} [encoding], default is utf-8, other encoding will encode by iconv-lite
- *  - {Number} [duration], default is one houre(24 * 3600000 ms), must >= 60s.
+ *  - {Number} [duration], default is one hour(3600000 ms), must >= 60s.
  *  - {String} [mode], default is '0666'.
  *  - {Number} [buffer] buffer duration, default is 1000ms
  *  - {Boolean} [mkdir] try to mkdir in each cut, make sure dir exist.


### PR DESCRIPTION
default duration value is "ONE_HOUR".
so it means 60*60*1000 ms, not 24*3600000 ms.